### PR TITLE
Update CorsairLink plugin description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ From the community (notify me if I'm missing some):
 * https://github.com/medevil84/FanControl.AquacomputerHighFlowNext to interface with aquacomputer HighFlowNext 
 * https://github.com/FoPzl/FanControl.AquacomputerQuadro to interface with aquacomputer Quadro 
 * https://github.com/vision57/FanControl.GPU-Z
-* https://github.com/EvanMulawski/FanControl.CorsairLink to interface with Corsair Commander controllers
+* https://github.com/EvanMulawski/FanControl.CorsairLink to interface with Corsair Commander controllers and Hydro liquid coolers
 
 From Rem0o
 * (EXPERIMENTAL) https://github.com/Rem0o/FanControl.ADLX (AMD gpus)


### PR DESCRIPTION
Updates the description for the CorsairLink plugin to note support for Hydro liquid coolers.