### PR TITLE
Add Acer-PO3-640 plugin to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The plugin system lets you inject any type of sensor into FanControl. See the [P
 | [FanControl.LenovoPlugin](https://github.com/jiarandiana0307/FanControl.LenovoPlugin) | Lenovo laptops with `Lenovo ACPI-Compliant Virtual Power Controller` |
 | [FanControl.GigabyteWaterforce](https://github.com/brenoperucchi/FanControl.GigabyteWaterforce) | GIGABYTE AORUS WATERFORCE X AIO coolers — X240, X280, X360 |
 | [FanControl.AcerPredatorPH315](https://github.com/phaax/FanControl.AcerPredatorPH315) | Native fan control for the Acer Predator Helios 300 (PH315-53) |
+| [FanControl.Acer-PO3-640](https://github.com/R2D2VaderBeef/FanControl.Acer-PO3-640) | Acer Predator Orion 3000 PO3-640 desktop (configurable for other models) |
 
 ## Issues and Hardware Compatibility
 


### PR DESCRIPTION
I've created [a plugin](https://github.com/R2D2VaderBeef/FanControl.Acer-PO3-640) that allows Fan Control to control the CPU /case fans on the Acer Predator Orion 3000 PO3-640 (with an editable config / instructions for other models). 